### PR TITLE
[iOS] Sanitize the EXIF data.

### DIFF
--- a/ios/ReactNativeExif.xcodeproj/project.pbxproj
+++ b/ios/ReactNativeExif.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		09AAA3D31ECFA12C00B8ECD7 /* NSDictionary+JSON.m in Sources */ = {isa = PBXBuildFile; fileRef = 09AAA3D21ECFA12C00B8ECD7 /* NSDictionary+JSON.m */; };
 		327633601BFAAE28004DA88E /* ReactNativeExif.m in Sources */ = {isa = PBXBuildFile; fileRef = 3276335D1BFAAE28004DA88E /* ReactNativeExif.m */; };
 /* End PBXBuildFile section */
 
@@ -23,6 +24,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		09AAA3D11ECFA12C00B8ECD7 /* NSDictionary+JSON.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSDictionary+JSON.h"; sourceTree = "<group>"; };
+		09AAA3D21ECFA12C00B8ECD7 /* NSDictionary+JSON.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSDictionary+JSON.m"; sourceTree = "<group>"; };
 		327633421BFAAD7E004DA88E /* libReactNativeExif.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libReactNativeExif.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		3276335D1BFAAE28004DA88E /* ReactNativeExif.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ReactNativeExif.m; sourceTree = "<group>"; };
 		93D3C9D61D1988810029CFEB /* ReactNativeExif.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ReactNativeExif.h; sourceTree = "<group>"; };
@@ -60,6 +63,8 @@
 			children = (
 				3276335D1BFAAE28004DA88E /* ReactNativeExif.m */,
 				93D3C9D61D1988810029CFEB /* ReactNativeExif.h */,
+				09AAA3D11ECFA12C00B8ECD7 /* NSDictionary+JSON.h */,
+				09AAA3D21ECFA12C00B8ECD7 /* NSDictionary+JSON.m */,
 			);
 			path = ReactNativeExif;
 			sourceTree = "<group>";
@@ -120,6 +125,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				09AAA3D31ECFA12C00B8ECD7 /* NSDictionary+JSON.m in Sources */,
 				327633601BFAAE28004DA88E /* ReactNativeExif.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -223,7 +229,7 @@
 					"$(inherited)",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					"$(SRCROOT)/../../react-native/React/**",
-					"$(SRCROOT)/../node_modules/react-native/React/**"
+					"$(SRCROOT)/../node_modules/react-native/React/**",
 				);
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/ios/ReactNativeExif/NSDictionary+JSON.h
+++ b/ios/ReactNativeExif/NSDictionary+JSON.h
@@ -1,0 +1,7 @@
+#import <Foundation/Foundation.h>
+
+@interface NSDictionary (JSON)
+
+- (NSDictionary *)sanitizedDictionaryForJSONSerialization;
+
+@end

--- a/ios/ReactNativeExif/NSDictionary+JSON.m
+++ b/ios/ReactNativeExif/NSDictionary+JSON.m
@@ -1,0 +1,29 @@
+#import "NSDictionary+JSON.h"
+
+@implementation NSDictionary (JSON)
+
+- (NSDictionary *)sanitizedDictionaryForJSONSerialization {
+    if ([NSJSONSerialization isValidJSONObject:self]) {
+        return self;
+    }
+
+    NSMutableDictionary *sanitizedSelf = [NSMutableDictionary new];
+
+    for (NSString *key in self) {
+        id value = self[key];
+        if ([value isKindOfClass:[NSString class]] ||
+            [value isKindOfClass:[NSNumber class]] ||
+            [value isKindOfClass:[NSArray class]] ||
+            [value isKindOfClass:[NSNull class]]) {
+            sanitizedSelf[key] = value;
+        }
+
+        if ([value isKindOfClass:[NSDictionary class]]) {
+            sanitizedSelf[key] = [(NSDictionary *)value sanitizedDictionaryForJSONSerialization];
+        }
+    }
+
+    return sanitizedSelf;
+}
+
+@end

--- a/ios/ReactNativeExif/ReactNativeExif.m
+++ b/ios/ReactNativeExif/ReactNativeExif.m
@@ -55,7 +55,8 @@ RCT_EXPORT_METHOD(getExif:(NSString *)path resolver:(RCTPromiseResolveBlock)reso
     }
     @catch (NSException *exception) {
         NSLog(@"%@", exception.reason);
-        NSError *error = [NSError errorWithDomain:@"world" code:200 userInfo:@"error"];
+        NSDictionary *userInfo = @{NSLocalizedDescriptionKey: exception.reason};
+        NSError *error = [NSError errorWithDomain:@"world" code:200 userInfo:userInfo];
         reject(@"fail", @"getExif", error);
     }
 

--- a/ios/ReactNativeExif/ReactNativeExif.m
+++ b/ios/ReactNativeExif/ReactNativeExif.m
@@ -3,6 +3,7 @@
 #import <React/RCTEventDispatcher.h>
 #import <React/RCTLog.h>
 #import <AssetsLibrary/AssetsLibrary.h>
+#import "NSDictionary+JSON.h"
 
 @import Photos;
 
@@ -21,7 +22,7 @@ RCT_EXPORT_METHOD(getExif:(NSString *)path resolver:(RCTPromiseResolveBlock)reso
             ALAssetsLibraryAssetForURLResultBlock resultblock = ^(ALAsset *myasset)
             {
                 
-                NSDictionary *exif = [[myasset defaultRepresentation] metadata];
+                NSDictionary *exif = [[[myasset defaultRepresentation] metadata] sanitizedDictionaryForJSONSerialization];
                 NSDictionary *mutableExif = [exif mutableCopy];
                 [mutableExif setValue:myasset.defaultRepresentation.filename forKey:@"originalUri"];   
                 resolve(mutableExif);


### PR DESCRIPTION
**Issue**
React Native throws an error when converting the EXIF data for photos that contain `NSData` values. To send Objective-C values to javascript, React Native uses `NSJSONSerialization`, which doesn't support `NSData` values.
https://developer.apple.com/reference/foundation/jsonserialization

**Fix**
Makes sure the EXIF data returned only contains values of type `NSArray`, `NSDictionary`, `NSString`, `NSNumber`, or `NSNull`.