### PR TITLE
add createJSModules to support apps using react native < 0.47

### DIFF
--- a/android/src/main/java/com/devialab/exif/RCTExifPackage.java
+++ b/android/src/main/java/com/devialab/exif/RCTExifPackage.java
@@ -5,6 +5,7 @@ import java.util.Collections;
 import java.util.List;
 
 import com.facebook.react.ReactPackage;
+import com.facebook.react.bridge.JavaScriptModule;
 import com.facebook.react.bridge.NativeModule;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.uimanager.ViewManager;
@@ -17,6 +18,15 @@ public class RCTExifPackage implements ReactPackage {
         return Arrays.<NativeModule>asList(
                 new Exif(reactContext)
         );
+    }
+
+    // Do not annotate the method with @Override
+    // This will provide backward compatibility for apps using react-native version < 0.47
+    // Breaking change in react-native version 0.47 : Android Remove unused createJSModules calls
+    // Find more information here : https://github.com/facebook/react-native/releases/tag/v0.47.2
+    // https://github.com/facebook/react-native/commit/ce6fb337a146e6f261f2afb564aa19363774a7a8
+    public List<Class<? extends JavaScriptModule>> createJSModules() {
+        return Collections.emptyList();
     }
 
     @Override


### PR DESCRIPTION
Problem : Support react native applications using react-native < 0.47

Solution :  add createJSModules() in the RCTExifPackage file that implements ReactPackage (Do not annotate it with @Override. This will provide backward compatibilty

Please note if you agree with the fix , it would need publishing a new version of the package. Would appreciate your prompt reply.