### PR TITLE
Fixed issue with native module not resolving or rejecting promises

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,6 +37,15 @@ Exif.getExif = function (uri) {
     });
 };
 
+Exif.getExifWithLocalIdentifier = function (localIdentifier) {
+    return NativeModules.ReactNativeExif.getExifWithLocalIdentifier(localIdentifier).then(result => {
+        if (Platform.OS === 'android') {
+            return unifyAndroid(result);
+        }
+        return unifyIOS(result);
+    });
+};
+
 Exif.getLatLong = function (uri) {
     const path = uri.replace('file://', '');
     return NativeModules.ReactNativeExif.getLatLong(path);

--- a/ios/ReactNativeExif/ReactNativeExif.h
+++ b/ios/ReactNativeExif/ReactNativeExif.h
@@ -4,5 +4,6 @@
 
 + (void)getExif:(NSString *)path resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject;
 + (void)getLatLong:(NSString *)path resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject;
++ (void)getExifWithLocalIdentifier:(NSString *)localIdentifier resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject;
 
 @end

--- a/ios/ReactNativeExif/ReactNativeExif.m
+++ b/ios/ReactNativeExif/ReactNativeExif.m
@@ -1,5 +1,3 @@
-#include <stdio.h>
-
 #import "ReactNativeExif.h"
 #import <React/RCTBridge.h>
 #import <React/RCTEventDispatcher.h>
@@ -20,7 +18,6 @@ RCT_EXPORT_METHOD(getExif:(NSString *)path resolver:(RCTPromiseResolveBlock)reso
     @try {
 
         if([path hasPrefix:@"assets-library"]) {
-            printf("assets library");
 
             ALAssetsLibraryAssetForURLResultBlock resultblock = ^(ALAsset *myasset)
             {
@@ -28,7 +25,6 @@ RCT_EXPORT_METHOD(getExif:(NSString *)path resolver:(RCTPromiseResolveBlock)reso
                 NSDictionary *exif = [[[myasset defaultRepresentation] metadata] sanitizedDictionaryForJSONSerialization];
                 NSDictionary *mutableExif = [exif mutableCopy];
                 [mutableExif setValue:myasset.defaultRepresentation.filename forKey:@"originalUri"];
-                printf("Resolving first");
                 resolve(mutableExif);
 
             };
@@ -38,33 +34,23 @@ RCT_EXPORT_METHOD(getExif:(NSString *)path resolver:(RCTPromiseResolveBlock)reso
             [assetslibrary assetForURL:url
                            resultBlock:resultblock
                           failureBlock:^(NSError *error) {
-                              printf("couldnt get photo");
                               NSLog(@"error couldn't get photo");
-                              reject(@"exif.getExif", @"Failed to get exif", error);
                           }];
 
         } else {
-            PHFetchResult* assets = [PHAsset fetchAssetsWithLocalIdentifiers:@[path] options:nil];
-            
-            PHAsset *asset = assets.firstObject;
-            if (asset.mediaType == PHAssetMediaTypeImage) {
-                [[PHImageManager defaultManager] requestImageDataForAsset:asset options:nil resultHandler:^(NSData * _Nullable imageData, NSString * _Nullable dataUTI, UIImageOrientation orientation, NSDictionary * _Nullable info) {
-                    
-                    CGImageSourceRef mySourceRef = CGImageSourceCreateWithData((CFDataRef)imageData, NULL);
-                    if (mySourceRef != NULL)
-                    {
-                        NSDictionary *exif = (__bridge NSDictionary *)CGImageSourceCopyPropertiesAtIndex(mySourceRef,0,NULL);
-                        CFRelease(mySourceRef);
-                        
-                        NSDictionary *mutableExif = [exif mutableCopy];
-                        [mutableExif setValue:path forKey:@"originalUri"];
-                        resolve(mutableExif);
-                        return;
-                    }
-                }];
+
+            NSData* pngData = [NSData dataWithContentsOfFile:path];
+
+            CGImageSourceRef mySourceRef = CGImageSourceCreateWithData((CFDataRef)pngData, NULL);
+            if (mySourceRef != NULL)
+            {
+                NSDictionary *exif = (__bridge NSDictionary *)CGImageSourceCopyPropertiesAtIndex(mySourceRef,0,NULL);
+                CFRelease(mySourceRef);
+
+                NSDictionary *mutableExif = [exif mutableCopy];
+                [mutableExif setValue:path forKey:@"originalUri"];
+                resolve(mutableExif);
             }
-            
-            [NSException raise:@"Invalid local identifier" format:@"Local identifier of %@* is invalid", path];
         }
 
     }
@@ -106,7 +92,6 @@ RCT_EXPORT_METHOD(getLatLong:(NSString *)path resolver:(RCTPromiseResolveBlock)r
                      resultBlock:resultblock
                     failureBlock:^(NSError *error) {
                         NSLog(@"error couldn't get photo");
-                        reject(@"exif.getLatLong", @"Failed to get lat long", error);
                     }];
 
     } else {
@@ -122,22 +107,9 @@ RCT_EXPORT_METHOD(getLatLong:(NSString *)path resolver:(RCTPromiseResolveBlock)r
           if (! location) {
             return resolve(nil);
           }
-          
-          for(NSString *key in [location allKeys]) {
-              NSLog(@"%@ : %@",key, [location objectForKey:key]);
-          }
 
           NSNumber *latitude = [location objectForKey:@"Latitude"];
           NSNumber *longitude = [location objectForKey:@"Longitude"];
-          NSString *latitudeRef = [location objectForKey:@"LatitudeRef"];
-          NSString *longitudeRef = [location objectForKey:@"LongitudeRef"];
-          
-          if ([@"S" isEqualToString:latitudeRef]) {
-              latitude = @(- latitude.doubleValue);
-          }
-          if ([@"W" isEqualToString:longitudeRef]) {
-              longitude = @(- longitude.doubleValue);
-          }
 
           NSMutableDictionary *latLongDict = [[NSMutableDictionary alloc] init];
           [latLongDict setValue:latitude forKey:@"latitude"];
@@ -157,30 +129,30 @@ RCT_EXPORT_METHOD(getLatLong:(NSString *)path resolver:(RCTPromiseResolveBlock)r
 
 RCT_EXPORT_METHOD(getExifWithLocalIdentifier:(NSString *)localIdentifier resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
-    
+
     @try {
-        
+
         PHFetchResult* assets = [PHAsset fetchAssetsWithLocalIdentifiers:@[localIdentifier] options:nil];
         PHAsset *asset = assets.firstObject;
         if (asset.mediaType != PHAssetMediaTypeImage) {
             [NSException raise:@"Asset is not an image" format:@"Asset for provided local identifier %@* is not an image", localIdentifier];
             return;
         }
-        
+
         [[PHImageManager defaultManager] requestImageDataForAsset:asset options:nil resultHandler:^(NSData * _Nullable imageData, NSString * _Nullable dataUTI, UIImageOrientation orientation, NSDictionary * _Nullable info) {
             CGImageSourceRef mySourceRef = CGImageSourceCreateWithData((CFDataRef)imageData, NULL);
-            
+
             if (mySourceRef == NULL) {
                 [NSException raise:@"Could not load image" format:@"The image could not be loaded"];
             }
             NSDictionary *exif = (__bridge NSDictionary *)CGImageSourceCopyPropertiesAtIndex(mySourceRef,0,NULL);
             CFRelease(mySourceRef);
-            
+
             NSDictionary *mutableExif = [exif mutableCopy];
             [mutableExif setValue:localIdentifier forKey:@"originalUri"];
             resolve(mutableExif);
         }];
-        
+
     }
     @catch (NSException *exception) {
         NSLog(@"%@", exception.reason);
@@ -188,7 +160,7 @@ RCT_EXPORT_METHOD(getExifWithLocalIdentifier:(NSString *)localIdentifier resolve
         NSError *error = [NSError errorWithDomain:@"world" code:200 userInfo:userInfo];
         reject(@"fail", @"getExifWithLocalIdentifier", error);
     }
-    
+
 }
 
 @end

--- a/ios/ReactNativeExif/ReactNativeExif.m
+++ b/ios/ReactNativeExif/ReactNativeExif.m
@@ -1,3 +1,5 @@
+#include <stdio.h>
+
 #import "ReactNativeExif.h"
 #import <React/RCTBridge.h>
 #import <React/RCTEventDispatcher.h>
@@ -18,6 +20,7 @@ RCT_EXPORT_METHOD(getExif:(NSString *)path resolver:(RCTPromiseResolveBlock)reso
     @try {
 
         if([path hasPrefix:@"assets-library"]) {
+            printf("assets library");
 
             ALAssetsLibraryAssetForURLResultBlock resultblock = ^(ALAsset *myasset)
             {
@@ -25,6 +28,7 @@ RCT_EXPORT_METHOD(getExif:(NSString *)path resolver:(RCTPromiseResolveBlock)reso
                 NSDictionary *exif = [[[myasset defaultRepresentation] metadata] sanitizedDictionaryForJSONSerialization];
                 NSDictionary *mutableExif = [exif mutableCopy];
                 [mutableExif setValue:myasset.defaultRepresentation.filename forKey:@"originalUri"];
+                printf("Resolving first");
                 resolve(mutableExif);
 
             };
@@ -34,23 +38,33 @@ RCT_EXPORT_METHOD(getExif:(NSString *)path resolver:(RCTPromiseResolveBlock)reso
             [assetslibrary assetForURL:url
                            resultBlock:resultblock
                           failureBlock:^(NSError *error) {
+                              printf("couldnt get photo");
                               NSLog(@"error couldn't get photo");
+                              reject(@"exif.getExif", @"Failed to get exif", error);
                           }];
 
         } else {
-
-            NSData* pngData = [NSData dataWithContentsOfFile:path];
-
-            CGImageSourceRef mySourceRef = CGImageSourceCreateWithData((CFDataRef)pngData, NULL);
-            if (mySourceRef != NULL)
-            {
-                NSDictionary *exif = (__bridge NSDictionary *)CGImageSourceCopyPropertiesAtIndex(mySourceRef,0,NULL);
-                CFRelease(mySourceRef);
-
-                NSDictionary *mutableExif = [exif mutableCopy];
-                [mutableExif setValue:path forKey:@"originalUri"];
-                resolve(mutableExif);
+            PHFetchResult* assets = [PHAsset fetchAssetsWithLocalIdentifiers:@[path] options:nil];
+            
+            PHAsset *asset = assets.firstObject;
+            if (asset.mediaType == PHAssetMediaTypeImage) {
+                [[PHImageManager defaultManager] requestImageDataForAsset:asset options:nil resultHandler:^(NSData * _Nullable imageData, NSString * _Nullable dataUTI, UIImageOrientation orientation, NSDictionary * _Nullable info) {
+                    
+                    CGImageSourceRef mySourceRef = CGImageSourceCreateWithData((CFDataRef)imageData, NULL);
+                    if (mySourceRef != NULL)
+                    {
+                        NSDictionary *exif = (__bridge NSDictionary *)CGImageSourceCopyPropertiesAtIndex(mySourceRef,0,NULL);
+                        CFRelease(mySourceRef);
+                        
+                        NSDictionary *mutableExif = [exif mutableCopy];
+                        [mutableExif setValue:path forKey:@"originalUri"];
+                        resolve(mutableExif);
+                        return;
+                    }
+                }];
             }
+            
+            [NSException raise:@"Invalid local identifier" format:@"Local identifier of %@* is invalid", path];
         }
 
     }
@@ -92,6 +106,7 @@ RCT_EXPORT_METHOD(getLatLong:(NSString *)path resolver:(RCTPromiseResolveBlock)r
                      resultBlock:resultblock
                     failureBlock:^(NSError *error) {
                         NSLog(@"error couldn't get photo");
+                        reject(@"exif.getLatLong", @"Failed to get lat long", error);
                     }];
 
     } else {
@@ -107,9 +122,22 @@ RCT_EXPORT_METHOD(getLatLong:(NSString *)path resolver:(RCTPromiseResolveBlock)r
           if (! location) {
             return resolve(nil);
           }
+          
+          for(NSString *key in [location allKeys]) {
+              NSLog(@"%@ : %@",key, [location objectForKey:key]);
+          }
 
           NSNumber *latitude = [location objectForKey:@"Latitude"];
           NSNumber *longitude = [location objectForKey:@"Longitude"];
+          NSString *latitudeRef = [location objectForKey:@"LatitudeRef"];
+          NSString *longitudeRef = [location objectForKey:@"LongitudeRef"];
+          
+          if ([@"S" isEqualToString:latitudeRef]) {
+              latitude = @(- latitude.doubleValue);
+          }
+          if ([@"W" isEqualToString:longitudeRef]) {
+              longitude = @(- longitude.doubleValue);
+          }
 
           NSMutableDictionary *latLongDict = [[NSMutableDictionary alloc] init];
           [latLongDict setValue:latitude forKey:@"latitude"];
@@ -125,6 +153,42 @@ RCT_EXPORT_METHOD(getLatLong:(NSString *)path resolver:(RCTPromiseResolveBlock)r
       NSError *error = [NSError errorWithDomain:@"world" code:200 userInfo:userInfo];
       reject(@"fail", @"getLatLong", error);
   }
+}
+
+RCT_EXPORT_METHOD(getExifWithLocalIdentifier:(NSString *)localIdentifier resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject) {
+    
+    @try {
+        
+        PHFetchResult* assets = [PHAsset fetchAssetsWithLocalIdentifiers:@[localIdentifier] options:nil];
+        PHAsset *asset = assets.firstObject;
+        if (asset.mediaType != PHAssetMediaTypeImage) {
+            [NSException raise:@"Asset is not an image" format:@"Asset for provided local identifier %@* is not an image", localIdentifier];
+            return;
+        }
+        
+        [[PHImageManager defaultManager] requestImageDataForAsset:asset options:nil resultHandler:^(NSData * _Nullable imageData, NSString * _Nullable dataUTI, UIImageOrientation orientation, NSDictionary * _Nullable info) {
+            CGImageSourceRef mySourceRef = CGImageSourceCreateWithData((CFDataRef)imageData, NULL);
+            
+            if (mySourceRef == NULL) {
+                [NSException raise:@"Could not load image" format:@"The image could not be loaded"];
+            }
+            NSDictionary *exif = (__bridge NSDictionary *)CGImageSourceCopyPropertiesAtIndex(mySourceRef,0,NULL);
+            CFRelease(mySourceRef);
+            
+            NSDictionary *mutableExif = [exif mutableCopy];
+            [mutableExif setValue:localIdentifier forKey:@"originalUri"];
+            resolve(mutableExif);
+        }];
+        
+    }
+    @catch (NSException *exception) {
+        NSLog(@"%@", exception.reason);
+        NSDictionary *userInfo = @{NSLocalizedDescriptionKey: exception.reason};
+        NSError *error = [NSError errorWithDomain:@"world" code:200 userInfo:userInfo];
+        reject(@"fail", @"getExifWithLocalIdentifier", error);
+    }
+    
 }
 
 @end


### PR DESCRIPTION
Added new method getExifWithLocalIdentifier() that uses the photo local identifier to get the exif data. This prevents the issues some are having with the native module not resolving or rejecting the promise. This was happening because of permissions issues that are fixed by using the local identifier to get the image data.